### PR TITLE
Add readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,38 @@
+=== Benenson ===
+Contributors: @bigbitecreative
+Tags: theme-options, rtl-language-support, translation-ready, accessibility-ready, featured-images, full-width-template, custom-menu, blog, education, news
+Requires at least: 4.9.8
+Tested up to: 5.0
+Stable tag: 1.0.2
+License: GPLv3
+License URI: http://www.gnu.org/licenses/gpl-3.0.html
+
+== Description ==
+Named after the founder of the human rights group, Amnesty International, Benenson is an open-source WordPress theme built using Gutenberg. 
+
+== Changelog ==
+
+= 1.0.2 =
+* Fixes call to block localisation function for WPv5
+
+= 1.0.1 =
+* Removes unnecessary block deprecations.
+* Fixes button styles within the Gutenberg Editor.
+* Fixes some issues with html getting encoded within button links.
+* Fixes issue where default variables not set for hero image.
+* Corrects PHPCS cosmetic issues.
+
+= 1.0.0 =
+* Initial release
+
+== Upgrade Notice ==
+
+= 1.0.1 =
+* If using WPv5 without the Gutenberg plugin active, a fatal error will trigger when editing a Gutenberg page. 1.0.2 addresses this issue; upgrade immediately.
+
+== Resources ==
+* Playfair Display font © 2017 The Playfair Display Project Authors
+* Lato font © 2010-2011 tyPoland Lukasz Dziedzic
+* Feather Icons © 2013-2017 Cole Bemis
+* IcoMoon Free 2018 IcoMoon.io
+* Flickity.js © 2015-2018 Metafizzy


### PR DESCRIPTION
WP.org themes require a [readme.txt](https://make.wordpress.org/themes/handbook/review/required/#readme-txt-file); this PR adds one.