### PR TITLE
Post List Block Quantity

### DIFF
--- a/src/scripts/blocks/post-list/index.js
+++ b/src/scripts/blocks/post-list/index.js
@@ -20,7 +20,7 @@ const blockAttributes = {
     type: 'boolean',
   },
   amount: {
-    type: 'string',
+    type: 'integer',
   },
   custom: {
     type: 'array',


### PR DESCRIPTION
## Proposed Changes
This PR resolves an issue with the `quantity` attribute on the post list block. The attribute is saved in the database as an integer, but the datatype was declared as a string. This meant that Gutenberg was unable to retrieve the attribute value, and so it was defaulting to `3` in all cases.