### PR TITLE
Add pointer events none to the header content 

### DIFF
--- a/src/styles/components/header/_editor.scss
+++ b/src/styles/components/header/_editor.scss
@@ -7,3 +7,8 @@
   padding-right: 60px;
   padding-left: 60px;
 }
+
+// Stop the placeholder from causing capturing mouse events.
+.hero-content .editor-rich-text .editor-rich-text__tinymce:not([contenteditable]) {
+  pointer-events: none;
+}


### PR DESCRIPTION
## Proposed Changes
- Adds pointer events none to header content fields in the editor. As occasionally the fields would become unclickable

## Linked Issues
- Fixes part of #26  (Fixes the issue where you can't edit the content)

