### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   - "$HOME/.yarn"
   - "./node_modules"
 before_install:
-- yarn
+- travis_retry yarn
 jobs:
   include:
   - stage: lint


### PR DESCRIPTION
## Proposed Changes
- Add `travis_retry` to the `yarn` command. As `yarn` relies upon an external registry, if there are network issues, the build will fail. Allowing Travis to retry upon failure should prevent the whole build from erroring if there's a communication issue with the registry.

![](http://bigbite.im/zVohLt+)

This is untested, but should work.